### PR TITLE
Updated init.lua to Provide Alternative for Linux Users

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -24,6 +24,8 @@ return {
       local extension_path = codelldb:get_install_path() .. "/extension/"
       local codelldb_path = extension_path .. "adapter/codelldb"
       local liblldb_path = extension_path.. "lldb/lib/liblldb.dylib"
+	-- If you are on Linux, replace the line above with the line below:
+	-- local liblldb_path = extension_path .. "lldb/lib/liblldb.so"
       local cfg = require('rustaceanvim.config')
 
       vim.g.rustaceanvim = {


### PR DESCRIPTION
The current code will not work on Linux because of line 26. This will cause the debugger to throw an error. I added a comment with an alternative line that should work for Linux users.